### PR TITLE
add core_kernel and ctypes to requires, name to opam

### DIFF
--- a/META
+++ b/META
@@ -1,6 +1,6 @@
 version = "0.0.1"
 description = "TensorFlow bindings for OCaml."
-requires = "unix bigarray str bytes"
+requires = "unix bigarray str bytes core_kernel ctypes.foreign"
 archive(byte) = "tensorflow.cma"
 archive(byte, plugin) = "tensorflow.cma"
 archive(native) = "tensorflow.cmxa"

--- a/opam
+++ b/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+name:         "tensorflow"
 bug-reports:  "https://github.com/LaurentMazare/tensorflow-ocaml/issues"
 homepage:     "https://github.com/LaurentMazare/tensorflow-ocaml"
 dev-repo:     "git+https://github.com/LaurentMazare/tensorflow-ocaml.git"


### PR DESCRIPTION
This PR allows you to type ```opam pin add .``` in the project directory, as well as eliminates two linking errors when loading from ```utop``` or otherwise for ```core_kernel``` and ```ctypes.foreign``` (or maybe just ```ctypes```- unclear to me. Either seem to work when added to the ```META``` file.) 

Now, my final error is from the tensorflow library itself but that's probably my fault regarding my python library path. 

Thanks for getting this binding going!