### PR TITLE
Flush at the end of tf_gen

### DIFF
--- a/src/wrapper/tf_gen.ml
+++ b/src/wrapper/tf_gen.ml
@@ -4,4 +4,5 @@ let () =
   Format.fprintf fmt_c "#include \"c_api.h\"@.";
   Cstubs.write_c fmt_c ~prefix:"caml_" (module Tf_bindings.C);
   let fmt_ml = fmt "tf_generated.ml" in
-  Cstubs.write_ml fmt_ml ~prefix:"caml_" (module Tf_bindings.C)
+  Cstubs.write_ml fmt_ml ~prefix:"caml_" (module Tf_bindings.C);
+  flush_all ()


### PR DESCRIPTION
OCaml doesn't appear to guarantee flushing on exit, and said flushing doesn't
fire in my setup.  Thus, do it manually.