### PR TITLE
Use libtensorflow.so instead of libtensorflow_c.so

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Two possible ways to obtain it are:
     
       `git clone --recurse-submodules -b r1.0 https://github.com/tensorflow/tensorflow`
     1. In the `tensorflow` directory run `./configure` (you will be asked if you want to enable CUDA support).
-    1. Run `bazel build -c opt tensorflow:libtensorflow_c.so`.
-    1. The resulting library should then be in `bazel-bin/tensorflow/libtensorflow_c.so`.
+    1. Run `bazel build -c opt tensorflow:libtensorflow.so`.
+    1. The resulting library should then be in `bazel-bin/tensorflow/libtensorflow.so`.
 * You can download a prebuilt x86-64 linux binaries (CPU only) [libtensorflow.so.1.0](https://github.com/LaurentMazare/tensorflow-ocaml/releases/download/0.0.7/libtensorflow.so.1.0).
 
 ### Build a Simple Example


### PR DESCRIPTION
The two are identical, but the former is what is recommended
(and used by TensorFlow team to build binary releases of the TensorFlow
C library)

The existence of both targets is an unfortunate outcome of tensorflow/tensorflow@783c52e and tensorflow/tensorflow#3830 happening within days of each other.

FYI: The installation instructions can be simplified further as the TensorFlow C library is now included in binary releases of TensorFlow. The releases are available in URLs of the form:   `https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-TYPE-OS-ARCH-VERSION.tar.gz`. For example:

- CPU-only, Linux, x86_64, 1.0.0: https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.0.0.tar.gz
- GPU-enabled, Linux, x86_64, 1.0.0:
https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-1.0.0.tar.gz
- CPU-only, OS X, x86_64, 1.0.0:
https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-darwin-x86_64-1.0.0.tar.gz
- GPU-enabled, OS X, x86_64, 1.0.0:
https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-darwin-x86_64-1.0.0.tar.gz
