### PR TITLE
Changes required for the upcoming version of Core_kernel

### DIFF
--- a/src/gen_ops/gen.ml
+++ b/src/gen_ops/gen.ml
@@ -170,7 +170,7 @@ module Op = struct
         else "'" ^ type_attr
       in
       let type_ =
-        match List.Assoc.find types type_attr with
+        match List.Assoc.find ~equal:String.equal types type_attr with
         | None -> Type.Polymorphic (alpha, `allow_all)
         | Some types ->
           Polymorphic (alpha, `allow_only types)
@@ -374,7 +374,7 @@ let handle_one_op (op : Op.t) out_channel =
     List.fold op.inputs ~init:type_attr ~f:(fun acc (input : Input.t) ->
       match input.type_name with
       | None -> acc
-      | Some type_name when List.Assoc.mem acc type_name -> acc
+      | Some type_name when List.Assoc.mem ~equal:String.equal acc type_name -> acc
       | Some type_name ->
         let name = Input.caml_comp_name input in
         (type_name, sprintf "(Node.output_type %s)" name) :: acc)

--- a/src/graph/node.ml
+++ b/src/graph/node.ml
@@ -180,7 +180,7 @@ let packed_id (P t) = t.id
 let packed_output_idx (P t) = t.output_idx
 
 let get_attr t str =
-  List.Assoc.find t.attributes str
+  List.Assoc.find ~equal:String.equal t.attributes str
 
 let get_attr_bool t str =
   Option.bind (get_attr t str) (function

--- a/src/graph/ops_gradients.ml
+++ b/src/graph/ops_gradients.ml
@@ -120,7 +120,7 @@ let sigmoid_gradient ~self ~gradient =
 
 let matmul_gradient ~self ~gradient =
   let get_transpose str =
-    List.Assoc.find (N.attributes self) str
+    List.Assoc.find ~equal:String.equal (N.attributes self) str
     |> Option.value_map
         ~default:false
         ~f:(function
@@ -150,7 +150,7 @@ let matmul_gradient ~self ~gradient =
 
 let batch_matmul_gradient ~self ~gradient =
   let get_adj str =
-    List.Assoc.find (N.attributes self) str
+    List.Assoc.find ~equal:String.equal (N.attributes self) str
     |> Option.value_map
         ~default:false
         ~f:(function


### PR DESCRIPTION
I don't expect this to break with the current stable version of core_kernel but you should test before merging.
The labelled argument`~equal` will be mandatory for List functions.