### PR TITLE
Updated code for base v0.11.0

### DIFF
--- a/src/fnn/fnn.ml
+++ b/src/fnn/fnn.ml
@@ -315,13 +315,13 @@ let create_var dims ~init ~type_ =
   | `truncated_normal stddev -> Var.truncated_normal dims ~stddev ~type_
 
 let build_node t ~type_ =
-  let inputs = Hashtbl.create (module Id) () in
-  let explicit_vars = Hashtbl.create (module Id) () in
-  let dense_vars = Hashtbl.create (module Id) () in
-  let conv_vars = Hashtbl.create (module Id) () in
-  let splits = Hashtbl.create (module Id) () in
-  let var_names = Hashtbl.create (module Node.Id) () in
-  let all_nodes = Hashtbl.create (module Id) () in
+  let inputs = Hashtbl.create (module Id) in
+  let explicit_vars = Hashtbl.create (module Id) in
+  let dense_vars = Hashtbl.create (module Id) in
+  let conv_vars = Hashtbl.create (module Id) in
+  let splits = Hashtbl.create (module Id) in
+  let var_names = Hashtbl.create (module Node.Id) in
+  let all_nodes = Hashtbl.create (module Id) in
   let rec walk (P t) =
     let node =
       match t.op with
@@ -488,8 +488,8 @@ module Model = struct
       ; node
       ; placeholder
       ; inputs
-      ; save_nodes = Hashtbl.create (module String) ()
-      ; load_and_assign_nodes = Hashtbl.create (module String) ()
+      ; save_nodes = Hashtbl.create (module String)
+      ; load_and_assign_nodes = Hashtbl.create (module String)
       ; var_names
       ; explicit_vars
       ; all_nodes

--- a/src/graph/gradients.ml
+++ b/src/graph/gradients.ml
@@ -8,7 +8,7 @@ exception No_derivative_for_op of Node.Op_name.t
    that contains only float/double nodes.
 *)
 let uses_per_node node with_respect_to =
-  let uses_per_node = Hashtbl.create (module Node.Id) () in
+  let uses_per_node = Hashtbl.create (module Node.Id) in
   let rec is_useful node =
     let node_id = Node.packed_id node in
     let current_uses =
@@ -61,8 +61,8 @@ let gradient node ~with_respect_to =
     List.map with_respect_to ~f:Node.packed_id |> Set.of_list (module Node.Id)
   in
   let uses_per_node = uses_per_node (P node) with_respect_to in
-  let contributions = Hashtbl.create (module Node.Id) () in
-  let output_gradients = Hashtbl.create (module Node.Id) () in
+  let contributions = Hashtbl.create (module Node.Id) in
+  let output_gradients = Hashtbl.create (module Node.Id) in
   let rec add_contribution node ~gradient =
     let node_id = Node.packed_id node in
     match Hashtbl.find uses_per_node node_id with

--- a/src/graph/node.ml
+++ b/src/graph/node.ml
@@ -144,7 +144,7 @@ module Weak_table = struct
   type t = p Id_table.t
 
   let create () =
-    Hashtbl.create (module Id) ()
+    Hashtbl.create (module Id)
 
   let set t ~key ~data =
     Hashtbl.set t ~key:(id key) ~data:(P data)

--- a/src/graph/optimizers.ml
+++ b/src/graph/optimizers.ml
@@ -11,7 +11,7 @@ type 'a optimizer
    Using this is an overapproximation as we would only need the variables that
    can be reached from the node via a 'derivable' path. *)
 let get_all_vars node =
-  let processed_nodes = Hash_set.create (module Node.Id) () in
+  let processed_nodes = Hash_set.create (module Node.Id) in
   (* Using references here make the following code quite consise. *)
   let varsf = ref ([] : [ `float ] Node.t list) in
   let varsd = ref ([] : [ `double ] Node.t list) in

--- a/src/graph/registered_gradients.ml
+++ b/src/graph/registered_gradients.ml
@@ -1,6 +1,6 @@
 open Base
 
-let table = Hashtbl.create (module Node.Op_name) ()
+let table = Hashtbl.create (module Node.Op_name)
 
 type t =
   { f : 'a .
@@ -21,7 +21,7 @@ let add op t =
 
 let find = Hashtbl.find table
 
-let table_multi = Hashtbl.create (module Node.Op_name) ()
+let table_multi = Hashtbl.create (module Node.Op_name)
 
 type multi =
   { g : 'a .

--- a/src/graph/session.ml
+++ b/src/graph/session.ml
@@ -17,7 +17,7 @@ let create () =
   | Ok session ->
     { session
     ; graph
-    ; nodes = Hashtbl.create (module Node.Id) ()
+    ; nodes = Hashtbl.create (module Node.Id)
     ; variable_initializations = []
     }
 
@@ -65,7 +65,8 @@ let rec build t node =
     operation
 
 let run ?(inputs=[]) ?(outputs=[]) ?(targets=[]) t =
-  if List.contains_dup (List.map inputs ~f:fst)
+  let cmp (Node.P n1) (Node.P n2) = Node.Id.compare (Node.id n1) (Node.id n2) in
+  if List.contains_dup ~compare:cmp (List.map inputs ~f:fst)
   then failwith "Session.run: duplicate entry in [inputs].";
   let inputs =
     List.map inputs ~f:(fun (input, input_tensor) ->

--- a/src/graph/var.ml
+++ b/src/graph/var.ml
@@ -58,7 +58,7 @@ let uniformd = uniform ~type_:Double
 let get_init p = Node.Weak_table.find init_table p
 
 let get_all_vars node =
-  let processed_nodes = Hash_set.create (module Node.Id) () in
+  let processed_nodes = Hash_set.create (module Node.Id) in
   (* Using references here make the following code quite consise. *)
   let all_vars = ref [] in
   let rec vars (Node.P node) =


### PR DESCRIPTION
Jane Street has transitioned to Base v0.11.0 with non-backward-compatible changes, which broke some code in tensorflow. This PR is fixing them:
Hashtbl.create no longer takes the extra unit argument (), and 
List.contains_dup's compare argument is now mandatory; There was one use in session.ml, where I have provided the compare argument by comparing nodes based on their id, rather than with OCaml's pervasive compare function, which the previous version of tensorflow code was implicitly using, and which Jane Street is moving away from. But you should check that this comparison is what you want.