### PR TITLE
Fix fnn epoch

### DIFF
--- a/examples/fnn/mnist_conv_fnn.ml
+++ b/examples/fnn/mnist_conv_fnn.ml
@@ -6,7 +6,7 @@ open Tensorflow_fnn
 let label_count = Mnist_helper.label_count
 let image_dim = Mnist_helper.image_dim
 let batch_size = 256
-let steps = 2000
+let epochs = 235
 
 let conv2d =
   Fnn.conv2d ~w_init:(`normal 0.1) ~filter:(5, 5) ~strides:(1, 1) ~padding:`same
@@ -14,12 +14,6 @@ let max_pool = Fnn.max_pool ~filter:(2, 2) ~strides:(2, 2) ~padding:`same
 
 let () =
   let mnist = Mnist_helper.read_files () in
-  let epochs =
-    let sample_size = Array.get (Tensorflow_core.Tensor.dims  mnist.Mnist_helper.train_labels) 0 in
-    let batch_size = min sample_size batch_size in
-    steps / (sample_size / batch_size) + 1
-  in
-
   let input, input_id = Fnn.input ~shape:(D1 image_dim) in
   let model =
     Fnn.reshape input ~shape:(D3 (28, 28, 1))

--- a/examples/fnn/mnist_conv_fnn.ml
+++ b/examples/fnn/mnist_conv_fnn.ml
@@ -5,8 +5,8 @@ open Tensorflow_fnn
 
 let label_count = Mnist_helper.label_count
 let image_dim = Mnist_helper.image_dim
-let epochs = 2000
 let batch_size = 256
+let steps = 2000
 
 let conv2d =
   Fnn.conv2d ~w_init:(`normal 0.1) ~filter:(5, 5) ~strides:(1, 1) ~padding:`same
@@ -14,6 +14,12 @@ let max_pool = Fnn.max_pool ~filter:(2, 2) ~strides:(2, 2) ~padding:`same
 
 let () =
   let mnist = Mnist_helper.read_files () in
+  let epochs =
+    let sample_size = Array.get (Tensorflow_core.Tensor.dims  mnist.Mnist_helper.train_labels) 0 in
+    let batch_size = min sample_size batch_size in
+    steps / (sample_size / batch_size) + 1
+  in
+
   let input, input_id = Fnn.input ~shape:(D1 image_dim) in
   let model =
     Fnn.reshape input ~shape:(D3 (28, 28, 1))

--- a/src/fnn/fnn.ml
+++ b/src/fnn/fnn.ml
@@ -566,12 +566,6 @@ module Model = struct
       Optimizer.get optimizer ~loss ?varsf ?varsd
     in
     let samples = (Tensor.dims xs).(0) in
-    let batch_size =
-      match batch_size with
-      | None -> None
-      | Some batch_size when batch_size > samples -> None
-      | Some _ as s -> s
-    in
     let find_input id =
       match Hashtbl.find t.inputs id with
       | None -> failwith "missing input"
@@ -586,23 +580,34 @@ module Model = struct
     let inputs ~xs ~ys =
       f_or_d xs_placeholder xs :: f_or_d t.placeholder ys :: addn_inputs
     in
-    for epoch = 1 to epochs do
-      let inputs =
-        match batch_size with
-        | None -> inputs ~xs ~ys
-        | Some batch_size ->
-          let offset = ((epoch-1) * batch_size) % (samples - batch_size) in
+    let batches_per_epoch, batch_inputs =
+      match batch_size with
+      | None -> (1, fun _n -> inputs)
+      | Some batch_size when batch_size >= samples -> (1, fun _step -> inputs)
+      | Some batch_size ->
+        (samples / batch_size,
+        fun step ~xs ~ys ->
+          let offset = (step * batch_size) % (samples - batch_size) in
           let xs = Tensor.sub_left xs offset batch_size in
           let ys = Tensor.sub_left ys offset batch_size in
           inputs ~xs ~ys
-      in
-      let err =
-        Session.run
-          ~inputs
-          ~targets:optimizer
-          (scalar_f_or_d loss)
-      in
-      Stdio.printf "Epoch: %6d/%-6d   Loss: %.2f\n%!" epoch epochs err
+        )
+    in
+    for epoch = 1 to epochs do
+      let err_total = ref 0.0 in
+      for epoch_offset = 0 to batches_per_epoch-1 do
+        let step = (epoch-1) * batches_per_epoch + epoch_offset in
+        let inputs = batch_inputs step  ~xs ~ys in
+        let err =
+          Session.run
+            ~inputs
+            ~targets:optimizer
+            (scalar_f_or_d loss)
+        in
+        (* Calculate the mean error over all batches *)
+        err_total := !err_total +. err;
+      done;
+      Stdio.printf "Epoch: %6d/%-6d   Loss: %.2f\n%!" epoch epochs (!err_total /. Float.of_int batches_per_epoch)
     done
   in
   match Node.output_type t.node, t.eq with

--- a/src/fnn/fnn.ml
+++ b/src/fnn/fnn.ml
@@ -587,7 +587,7 @@ module Model = struct
       | Some batch_size ->
         (samples / batch_size,
         fun step ~xs ~ys ->
-          let offset = (step * batch_size) % (samples - batch_size) in
+          let offset = (step * batch_size) in
           let xs = Tensor.sub_left xs offset batch_size in
           let ys = Tensor.sub_left ys offset batch_size in
           inputs ~xs ~ys
@@ -595,9 +595,8 @@ module Model = struct
     in
     for epoch = 1 to epochs do
       let err_total = ref 0.0 in
-      for epoch_offset = 0 to batches_per_epoch-1 do
-        let step = (epoch-1) * batches_per_epoch + epoch_offset in
-        let inputs = batch_inputs step  ~xs ~ys in
+      for step = 0 to batches_per_epoch-1 do
+        let inputs = batch_inputs step ~xs ~ys in
         let err =
           Session.run
             ~inputs

--- a/src/fnn/fnn.mli
+++ b/src/fnn/fnn.mli
@@ -143,11 +143,11 @@ module Model : sig
     -> (Input_id.t * (float, 'c) Tensor.t) list
     -> (float, 'c) Tensor.t
 
-  (** [fit ~xs ~ys ?batch_size ~epoch ...] trains a model on the [xs] and [ys] as training data.
+  (** [fit ~xs ~ys ?batch_size ~epoch ...] trains a model using [xs] and [ys] as training data.
       Training will be done in batches of size [batch_size]. The total amount of training steps
-      is {!epochs * |xs| / batch_size}. The average err is printed for each epoch ({!|xs| / bach_size}) steps.
-      if [batch_size] is not given or is larger than {!|xs|}, it defaults to {!|xs|}.
-      After each epoch (|xs| / batch_size) the average loss for the epoch is printed to {!stdout}.
+      is [epochs * |xs| / batch_size]. If [batch_size] is not given or is larger than [|xs|], it defaults to [|xs|].
+      The last [|xs| mod batch_size] training samples are not used for training.
+      After each epoch the average loss for the epoch is printed to {!stdout}.
   *)
   val fit
     :  ?addn_inputs:(Input_id.t * (float, 'c) Tensor.t) list

--- a/src/fnn/fnn.mli
+++ b/src/fnn/fnn.mli
@@ -143,6 +143,12 @@ module Model : sig
     -> (Input_id.t * (float, 'c) Tensor.t) list
     -> (float, 'c) Tensor.t
 
+  (** [fit ~xs ~ys ?batch_size ~epoch ...] trains a model on the [xs] and [ys] as training data.
+      Training will be done in batches of size [batch_size]. The total amount of training steps
+      is {!epochs * |xs| / batch_size}. The average err is printed for each epoch ({!|xs| / bach_size}) steps.
+      if [batch_size] is not given or is larger than {!|xs|}, it defaults to {!|xs|}.
+      After each epoch (|xs| / batch_size) the average loss for the epoch is printed to {!stdout}.
+  *)
   val fit
     :  ?addn_inputs:(Input_id.t * (float, 'c) Tensor.t) list
     -> ?batch_size:int


### PR DESCRIPTION
In Fnn, the epochs arguments indicates the number of training steps of `batch_size`.
This is however contrary to the common use of epoch where one epoch is defined as a single pass through the entire training set. (https://www.quora.com/What-is-epochs-in-machine-learning)

This PR changes the epoch argument to Fnn.Model.fit to match the definition above. The examples are also modified to maintain the same behavior as before. 